### PR TITLE
Fix bufferifyFn bug

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -317,7 +317,7 @@ export class Base {
       }
 
       if (typeof v === 'bigint') {
-        return Buffer.from(value.toString(16), 'hex')
+        return Buffer.from(v.toString(16), 'hex')
       }
 
       if (ArrayBuffer.isView(v)) {


### PR DESCRIPTION
Current code incorrectly tries to convert the `value` value, when actually `v` value should be converted to Hex